### PR TITLE
nvmインストールパスを修正

### DIFF
--- a/.bash_profile
+++ b/.bash_profile
@@ -11,7 +11,7 @@ elif [ `uname` = "Darwin" ]; then
 	## mac
 
 	# nvm
-	source $(brew --prefix nvm)/nvm.sh
+	source ~/.nvm/nvm.sh
 
 fi
 


### PR DESCRIPTION
brewでのインストールから、home以下にgit cloneする方法に変更
それに伴いbash_profileのsourceパスを変更
