### PR TITLE
履歴を複数ターミナルで使用できるようにする対応

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -15,5 +15,8 @@ if [[ "$(uname)" == MINGW64_NT-10.0* ]]; then
 	_uname="MINGW64_NT-10.0"
 fi
 
+export PROMPT_COMMAND="history -a; history -c; history -r; $PROMPT_COMMAND"
+shopt -u histappend
+
 # 各環境のファイル読み込み
 [ -f $dir/$_uname/.bashrc ] && . $dir/$_uname/.bashrc


### PR DESCRIPTION
https://linuxfan.info/history_share#:~:text=Linux%E3%83%86%E3%82%AF%E3%83%8B%E3%83%83%E3%82%AF,%E7%AB%AF%E6%9C%AB%E3%82%A2%E3%83%97%E3%83%AA%E3%81%A7%E8%A4%87%E6%95%B0%E3%81%AE%E3%82%BF%E3%83%96%E3%82%92%E9%96%8B%E3%81%84%E3%81%9F%E3%82%8A%E3%80%81byobu%EF%BC%88tmux%E3%83%BBscreen%EF%BC%89%E3%81%A7%E8%A4%87%E6%95%B0%E3%81%AE%E7%AB%AF%E6%9C%AB%E3%82%92%E9%96%8B%E3%81%84%E3%81%9F%E3%82%8A%E3%81%97%E3%81%9F%E5%A0%B4%E5%90%88%E3%81%AB%E3%80%81%E5%90%84%E7%AB%AF%E6%9C%AB%E3%81%A7%E5%8B%95%E3%81%8FBash%E3%81%AE%E3%82%B3%E3%83%9E%E3%83%B3%E3%83%89%E5%B1%A5%E6%AD%B4%E3%82%92%E3%80%8C%E5%85%B1%E6%9C%89%E5%8C%96%E3%80%8D%E3%81%99%E3%82%8B%E6%96%B9%E6%B3%95%E3%82%92%E7%B4%B9%E4%BB%8B%E3%81%97%E3%81%BE%E3%81%99%E3%80%82

「PROMPT_COMMAND」は、プロンプトが表示される時に実行するコマンドを設定するものです。

「history -a」は、実行しているBashセッションのコマンド履歴を~/.bash_profileに追記します。

「history -c」は、実行しているBashセッションがメモリ上に持っているコマンド履歴を消去します。

「history -r」は、~/.bash_profileからコマンド履歴を読み込んで、実行しているBashセッションのコマンド履歴に設定します。

最後に「$PROMPT_COMMAND」を記述しているのは、別の行で別のコマンドを環境変数「PROMPT_COMMAND」に設定済みだった場合、上記の処理が終わってから実行するためです。

「shopt -u histappend」は、シェルのオプション指定「histappend（終了時にコマンド履歴を~/.bash_historyに保存する）」を無効化しています。